### PR TITLE
Add config option to hide spawn toast message

### DIFF
--- a/src/main/java/com/bartz24/voidislandcontrol/ClientEventHandler.java
+++ b/src/main/java/com/bartz24/voidislandcontrol/ClientEventHandler.java
@@ -22,7 +22,7 @@ public class ClientEventHandler {
                 if (atSpawn && Minecraft.getMinecraft().player.getGameProfile().getId()
                         .equals(player.getGameProfile().getId())) {
                     if (Minecraft.getMinecraft().getToastGui().getToast(IslandToast.class,
-                            IslandToast.Type.Island) == null)
+                            IslandToast.Type.Island) == null && !ConfigOptions.islandSettings.hideSpawnToast)
                         Minecraft.getMinecraft().getToastGui().add(new IslandToast(
                                 new TextComponentString("Create an island!"),
                                 new TextComponentString("/" + ConfigOptions.commandSettings.commandName + " for help")));

--- a/src/main/java/com/bartz24/voidislandcontrol/config/ConfigOptions.java
+++ b/src/main/java/com/bartz24/voidislandcontrol/config/ConfigOptions.java
@@ -75,6 +75,8 @@ public class ConfigOptions {
 		public boolean allowIslandCreation = true;
 		@Config.Comment("Reset players inventory with the starting inventory")
 		public boolean resetInventory = true;
+		@Config.Comment("Hide spawn toast")
+		public boolean hideSpawnToast = false;
 		@Config.Comment("Custom islands using the structure block data. Files are to be placed in the "
 				+ References.ModID
 				+ "structures config folder. The names in this list should be the same as the structure names. "


### PR DESCRIPTION
Some modpacks would benefit from being able to hide the "Create an island!" toast message.

This very small patch adds such an option. It should have no performance impact, and by default, won't change anything to the current state of the mod.