### PR TITLE
Add config option for handleRespawn

### DIFF
--- a/src/main/java/com/bartz24/voidislandcontrol/EventHandler.java
+++ b/src/main/java/com/bartz24/voidislandcontrol/EventHandler.java
@@ -283,21 +283,23 @@ public class EventHandler {
 
     @SubscribeEvent
     public void onPlayerRespawn(PlayerRespawnEvent event) {
-        EntityPlayer player = event.player;
+        if (ConfigOptions.islandSettings.handleRespawn) {
+            EntityPlayer player = event.player;
 
-        if (player.getEntityWorld().getWorldInfo().getTerrainType() instanceof WorldTypeVoid) {
-            if (player.getBedLocation() == null
-                    || player.getBedSpawnLocation(player.getEntityWorld(), player.getBedLocation(), true) == null) {
+            if (player.getEntityWorld().getWorldInfo().getTerrainType() instanceof WorldTypeVoid) {
+                if (player.getBedLocation() == null
+                        || player.getBedSpawnLocation(player.getEntityWorld(), player.getBedLocation(), true) == null) {
 
-                IslandPos iPos = IslandManager.getPlayerIsland(player.getGameProfile().getId());
+                    IslandPos iPos = IslandManager.getPlayerIsland(player.getGameProfile().getId());
 
-                BlockPos pos = new BlockPos(0, ConfigOptions.islandSettings.islandYLevel, 0);
-                if (iPos != null)
-                    pos = new BlockPos(iPos.getX() * ConfigOptions.islandSettings.islandDistance,
-                            ConfigOptions.islandSettings.islandYLevel,
-                            iPos.getY() * ConfigOptions.islandSettings.islandDistance);
+                    BlockPos pos = new BlockPos(0, ConfigOptions.islandSettings.islandYLevel, 0);
+                    if (iPos != null)
+                        pos = new BlockPos(iPos.getX() * ConfigOptions.islandSettings.islandDistance,
+                                ConfigOptions.islandSettings.islandYLevel,
+                                iPos.getY() * ConfigOptions.islandSettings.islandDistance);
 
-                IslandManager.tpPlayerToPos(player, pos, iPos);
+                    IslandManager.tpPlayerToPos(player, pos, iPos);
+                }
             }
         }
     }

--- a/src/main/java/com/bartz24/voidislandcontrol/config/ConfigOptions.java
+++ b/src/main/java/com/bartz24/voidislandcontrol/config/ConfigOptions.java
@@ -92,6 +92,8 @@ public class ConfigOptions {
 		public boolean forceSpawn = false;
 		@Config.Comment("Sets how long the buffs are given when spawning on an island in ticks (I think)")
 		public int buffTimer = 1200;
+		@Config.Comment("Shoule VoidIslandControl handle player respawn? Disabling this would make players without a island respawn at worldspawn instead of 0,0")
+		public boolean handleRespawn = true;
 
 		@Config.Comment("Settings for the grass island")
 		public GrassIslandSettings grassSettings = new GrassIslandSettings();


### PR DESCRIPTION
So I'm making a modpack that uses VoidIslandControl.
I used PerfectSpawn to set the world spawn in the End at 10,75,10 (since 0,0 is the portal)
and I disabled island creation for VoidIslandControl, but it keeps trying to tp players to 0,0 which is the "spawn island", so I wonder if you can merge this, it's just a simple config option.